### PR TITLE
Make HTTP/1 transports a behaviour

### DIFF
--- a/lib/xhttp1/transport.ex
+++ b/lib/xhttp1/transport.ex
@@ -1,0 +1,15 @@
+defmodule XHTTP1.Transport do
+  @callback connect(hostname :: charlist(), :inet.port_number(), opts :: Keyword.t()) ::
+              {:ok, socket :: term()} | {:error, reason :: term()}
+
+  @callback getopts(socket :: term(), option_names :: [atom()]) ::
+              {:ok, opts :: Keyword.t()} | {:error, reason :: term()}
+
+  @callback setopts(socket :: term(), opts :: Keyword.t()) :: :ok | {:error, reason :: term()}
+
+  @callback close(socket :: term()) :: :ok
+
+  @callback send(socket :: term(), packet :: iodata()) :: :ok | {:error, reason :: term()}
+
+  @callback message_tags() :: {ok_tag :: atom(), error_tag :: atom(), close_tag :: atom()}
+end

--- a/lib/xhttp1/transport/ssl.ex
+++ b/lib/xhttp1/transport/ssl.ex
@@ -1,0 +1,13 @@
+defmodule XHTTP1.Transport.SSL do
+  @behaviour XHTTP1.Transport
+
+  defdelegate connect(hostname, port, options), to: :ssl
+  defdelegate getopts(socket, opts), to: :ssl
+  defdelegate setopts(socket, opts), to: :ssl
+  defdelegate close(socket), to: :ssl
+  defdelegate send(socket, packet), to: :ssl
+
+  def message_tags() do
+    {:ssl, :ssl_error, :ssl_close}
+  end
+end

--- a/lib/xhttp1/transport/tcp.ex
+++ b/lib/xhttp1/transport/tcp.ex
@@ -1,0 +1,13 @@
+defmodule XHTTP1.Transport.TCP do
+  @behaviour XHTTP1.Transport
+
+  defdelegate connect(hostname, port, options), to: :gen_tcp
+  defdelegate getopts(socket, opts), to: :inet
+  defdelegate setopts(socket, opts), to: :inet
+  defdelegate close(socket), to: :gen_tcp
+  defdelegate send(socket, packet), to: :gen_tcp
+
+  def message_tags() do
+    {:tcp, :tcp_error, :tcp_close}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -40,6 +40,8 @@ defmodule XHTTP1.TestHelpers do
 end
 
 defmodule XHTTP1.TestHelpers.TCPMock do
+  @behaviour XHTTP1.Transport
+
   def connect(hostname, port, opts \\ []) do
     Kernel.send(self(), {:tcp_mock, :connect, [hostname, port, opts]})
     {:ok, make_ref()}
@@ -63,5 +65,9 @@ defmodule XHTTP1.TestHelpers.TCPMock do
   def send(socket, data, opts \\ []) do
     Kernel.send(self(), {:tcp_mock, :send, [socket, data, opts]})
     :ok
+  end
+
+  def message_tags() do
+    {:tcp, :tcp_error, :tcp_close}
   end
 end

--- a/test/xhttp1/integration_test.exs
+++ b/test/xhttp1/integration_test.exs
@@ -1,7 +1,7 @@
 defmodule XHTTP1.IntegrationTest do
   use ExUnit.Case, async: true
   import XHTTP1.TestHelpers
-  alias XHTTP1.Conn
+  alias XHTTP1.{Conn, Transport}
 
   @moduletag :integration
 
@@ -19,7 +19,7 @@ defmodule XHTTP1.IntegrationTest do
   end
 
   test "ssl, path, long body - httpbin.org" do
-    assert {:ok, conn} = Conn.connect("httpbin.org", 443, transport: :ssl)
+    assert {:ok, conn} = Conn.connect("httpbin.org", 443, transport: Transport.SSL)
     assert {:ok, conn, request} = Conn.request(conn, "GET", "/bytes/50000", [], nil)
     assert {:ok, conn, responses} = receive_stream(conn)
 
@@ -31,7 +31,7 @@ defmodule XHTTP1.IntegrationTest do
   end
 
   test "keep alive - httpbin.org" do
-    assert {:ok, conn} = Conn.connect("httpbin.org", 443, transport: :ssl)
+    assert {:ok, conn} = Conn.connect("httpbin.org", 443, transport: Transport.SSL)
     assert {:ok, conn, request} = Conn.request(conn, "GET", "/", [], nil)
     assert {:ok, conn, responses} = receive_stream(conn)
 
@@ -41,7 +41,7 @@ defmodule XHTTP1.IntegrationTest do
     assert {:headers, ^request, _} = headers
     assert merge_body(responses, request) =~ "SEE ALSO"
 
-    assert {:ok, conn} = Conn.connect("httpbin.org", 443, transport: :ssl)
+    assert {:ok, conn} = Conn.connect("httpbin.org", 443, transport: Transport.SSL)
     assert {:ok, conn, request} = Conn.request(conn, "GET", "/", [], nil)
     assert {:ok, conn, responses} = receive_stream(conn)
 


### PR DESCRIPTION
@ericmj this is how a behaviour for transports would look like I think. IMO it looks really good, and the changes are quite contained. The ugliest change is in the `Conn.stream/2` function which now has to find the message tags for the given transport and dispatch based on that as well, but I think keeping the pattern matching and everything it's still very readable. 

I also had to go with `XHTTP1.Transport` instead of a transport shared by `XHTTP1` and `XHTTP2` because `XHTTP2` requires stuff like `:ssl.negotiated_protocol/2`. We could go ahead and make those calls optional so that we can share transports. We can see later on though. :)