### PR TITLE
Use a real TCP socket in HTTP/1 tests

### DIFF
--- a/lib/xhttp1/conn.ex
+++ b/lib/xhttp1/conn.ex
@@ -62,6 +62,10 @@ defmodule XHTTP1.Conn do
     transport = Keyword.get(opts, :transport, :gen_tcp)
     transport_opts = [packet: :raw, mode: :binary, active: true]
 
+    if transport not in [:gen_tcp, :ssl] do
+      raise ArgumentError, "the :transport option must be either :gen_tcp or :ssl"
+    end
+
     with {:ok, socket} <- transport.connect(String.to_charlist(hostname), port, transport_opts),
          :ok <- inet_opts(transport, socket) do
       {:ok, %Conn{socket: socket, host: hostname, transport: transport, state: :open}}
@@ -530,7 +534,7 @@ defmodule XHTTP1.Conn do
   defp normalize_method(binary) when is_binary(binary), do: String.upcase(binary)
 
   defp transport_to_inet(:gen_tcp), do: :inet
-  defp transport_to_inet(other), do: other
+  defp transport_to_inet(:ssl), do: :ssl
 
   defp new_request(ref, state, method) do
     %{

--- a/lib/xhttp1/conn.ex
+++ b/lib/xhttp1/conn.ex
@@ -63,7 +63,8 @@ defmodule XHTTP1.Conn do
     transport_opts = [packet: :raw, mode: :binary, active: true]
 
     if transport not in [:gen_tcp, :ssl] do
-      raise ArgumentError, "the :transport option must be either :gen_tcp or :ssl"
+      raise ArgumentError,
+            "the :transport option must be either :gen_tcp or :ssl, got: #{inspect(transport)}"
     end
 
     with {:ok, socket} <- transport.connect(String.to_charlist(hostname), port, transport_opts),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -39,29 +39,15 @@ defmodule XHTTP1.TestHelpers do
   end
 end
 
-defmodule XHTTP1.TestHelpers.TCPMock do
-  def connect(hostname, port, opts \\ []) do
-    Kernel.send(self(), {:tcp_mock, :connect, [hostname, port, opts]})
-    {:ok, make_ref()}
+defmodule XHTTP1.TestHelpers.Server do
+  def start() do
+    {:ok, listen_socket} = :gen_tcp.listen(0, mode: :binary, packet: :raw)
+    spawn_link(fn -> loop(listen_socket) end)
+    :inet.port(listen_socket)
   end
 
-  def close(socket) do
-    Kernel.send(self(), {:tcp_mock, :close, [socket]})
-    :ok
-  end
-
-  def getopts(socket, list) do
-    Kernel.send(self(), {:tcp_mock, :getopts, [socket, list]})
-    {:ok, Enum.map(list, &{&1, 0})}
-  end
-
-  def setopts(socket, opts) do
-    Kernel.send(self(), {:tcp_mock, :setopts, [socket, opts]})
-    :ok
-  end
-
-  def send(socket, data, opts \\ []) do
-    Kernel.send(self(), {:tcp_mock, :send, [socket, data, opts]})
-    :ok
+  defp loop(listen_socket) do
+    {:ok, _socket} = :gen_tcp.accept(listen_socket)
+    loop(listen_socket)
   end
 end

--- a/test/xhttp1/conn_properties_test.exs
+++ b/test/xhttp1/conn_properties_test.exs
@@ -3,10 +3,11 @@ defmodule XHTTP1.ConnPropertiesTest do
   use ExUnitProperties
   import XHTTP1.TestHelpers
   alias XHTTP1.Conn
-  alias XHTTP1.TestHelpers.TCPMock
+  alias XHTTP1.TestHelpers.Server
 
   setup do
-    assert {:ok, conn} = Conn.connect("localhost", 80, transport: TCPMock)
+    {:ok, port} = Server.start()
+    assert {:ok, conn} = Conn.connect("localhost", port, transport: :gen_tcp)
     [conn: conn]
   end
 

--- a/test/xhttp1/conn_test.exs
+++ b/test/xhttp1/conn_test.exs
@@ -1,10 +1,11 @@
 defmodule XHTTP1.ConnTest do
   use ExUnit.Case, async: true
   alias XHTTP1.Conn
-  alias XHTTP1.TestHelpers.TCPMock
+  alias XHTTP1.TestHelpers.Server
 
   setup do
-    assert {:ok, conn} = Conn.connect("localhost", 80, transport: TCPMock)
+    {:ok, port} = Server.start()
+    assert {:ok, conn} = Conn.connect("localhost", port, transport: :gen_tcp)
     [conn: conn]
   end
 


### PR DESCRIPTION
\cc @fishcakez @josevalim 

Barebones for now, but I think it's all we need for HTTP/1 tests.