### PR TITLE
Handle case when HTTP 1.x server returns response, pauses, then closes connection

### DIFF
--- a/lib/xhttp1/conn.ex
+++ b/lib/xhttp1/conn.ex
@@ -240,7 +240,7 @@ defmodule XHTTP1.Conn do
     conn = put_in(conn.state, :closed)
     conn = request_done(conn)
 
-    if request.body == :until_closed do
+    if request && request.body == :until_closed do
       {:ok, conn, [{:done, request.ref}]}
       # TODO: Notify that we are closed
     else

--- a/lib/xhttp1/conn.ex
+++ b/lib/xhttp1/conn.ex
@@ -481,6 +481,7 @@ defmodule XHTTP1.Conn do
     conn = pop_request(conn)
 
     cond do
+      !request -> close(conn)
       "close" in request.connection -> close(conn)
       request.version >= {1, 1} -> conn
       "keep-alive" in request.connection -> conn

--- a/lib/xhttp1/conn.ex
+++ b/lib/xhttp1/conn.ex
@@ -481,7 +481,7 @@ defmodule XHTTP1.Conn do
     conn = pop_request(conn)
 
     cond do
-      !request -> close(conn)
+      !request -> conn
       "close" in request.connection -> close(conn)
       request.version >= {1, 1} -> conn
       "keep-alive" in request.connection -> conn


### PR DESCRIPTION
This PR fixes a case when a request has been served, there is a pause, and the server explicitly closes the TCP connection.  Previously, receiving a `:tcp_closed` or `:ssl_closed` message when the conn's `request` was nil would raise an error.