### PR TITLE
Introduce a XHTTP.Transport behaviour

### DIFF
--- a/lib/xhttp/transport.ex
+++ b/lib/xhttp/transport.ex
@@ -1,0 +1,23 @@
+defmodule XHTTP.Transport do
+  @type state() :: term()
+
+  @callback connect(host :: String.t(), port :: :inet.port_number(), opts :: Keyword.t()) ::
+              {:ok, state()} | {:error, reason :: term()}
+
+  @callback negotiated_protocol(state()) ::
+              {:ok, protocol :: binary()} | {:error, reason :: term()}
+
+  @callback send(state(), payload :: iodata()) :: :ok | {:error, reason :: term()}
+
+  @callback close(state()) :: :ok | {:error, reason :: term()}
+
+  @callback recv(state(), bytes :: non_neg_integer()) ::
+              {:ok, binary()} | {:error, reason :: term()}
+
+  @callback setopts(state(), opts :: Keyword.t()) :: :ok | {:error, reason :: term()}
+
+  @callback getopts(state(), opts :: Keyword.t()) ::
+              {:ok, Keyword.t()} | {:error, reason :: term()}
+
+  @optional_callbacks [negotiated_protocol: 1]
+end

--- a/lib/xhttp/transport/ssl.ex
+++ b/lib/xhttp/transport/ssl.ex
@@ -1,0 +1,28 @@
+defmodule XHTTP.Transport.SSL do
+  @behaviour XHTTP.Transport
+
+  @impl true
+  def connect(host, port, opts) do
+    host
+    |> String.to_charlist()
+    |> :ssl.connect(port, opts)
+  end
+
+  @impl true
+  defdelegate negotiated_protocol(socket), to: :ssl
+
+  @impl true
+  defdelegate send(socket, payload), to: :ssl
+
+  @impl true
+  defdelegate close(socket), to: :ssl
+
+  @impl true
+  defdelegate recv(socket, bytes), to: :ssl
+
+  @impl true
+  defdelegate setopts(socket, opts), to: :ssl
+
+  @impl true
+  defdelegate getopts(socket, opts), to: :ssl
+end

--- a/lib/xhttp/transport/tcp.ex
+++ b/lib/xhttp/transport/tcp.ex
@@ -1,0 +1,25 @@
+defmodule XHTTP.Transport.TCP do
+  @behaviour XHTTP.Transport
+
+  @impl true
+  def connect(host, port, opts) do
+    host
+    |> String.to_charlist()
+    |> :gen_tcp.connect(port, opts)
+  end
+
+  @impl true
+  defdelegate send(socket, payload), to: :gen_tcp
+
+  @impl true
+  defdelegate close(socket), to: :gen_tcp
+
+  @impl true
+  defdelegate recv(socket, bytes), to: :gen_tcp
+
+  @impl true
+  defdelegate setopts(socket, opts), to: :inet
+
+  @impl true
+  defdelegate getopts(socket, opts), to: :inet
+end

--- a/lib/xhttp/util.ex
+++ b/lib/xhttp/util.ex
@@ -1,10 +1,8 @@
 defmodule XHTTP.Util do
   def inet_opts(transport, socket) do
-    inet = transport_to_inet(transport)
-
-    with {:ok, opts} <- inet.getopts(socket, [:sndbuf, :recbuf, :buffer]),
+    with {:ok, opts} <- transport.getopts(socket, [:sndbuf, :recbuf, :buffer]),
          buffer = calculate_buffer(opts),
-         :ok <- inet.setopts(socket, buffer: buffer) do
+         :ok <- transport.setopts(socket, buffer: buffer) do
       :ok
     else
       error ->
@@ -13,15 +11,12 @@ defmodule XHTTP.Util do
     end
   end
 
-  def transport_to_inet(:gen_tcp), do: :inet
-  def transport_to_inet(:ssl), do: :ssl
-
   def get_transport(opts, default) do
     transport = Keyword.get(opts, :transport, default)
 
-    if transport not in [:gen_tcp, :ssl] do
+    if transport not in [XHTTP.Transport.TCP, XHTTP.Transport.SSL] do
       raise ArgumentError,
-            "the :transport option must be either :gen_tcp or :ssl, got: #{inspect(transport)}"
+            "the :transport option must be either TCP or SSL, got: #{inspect(transport)}"
     end
 
     transport

--- a/lib/xhttpn/conn.ex
+++ b/lib/xhttpn/conn.ex
@@ -8,7 +8,7 @@ defmodule XHTTPN.Conn do
   @default_protocols [:http1, :http2]
 
   @default_transport_opts %{
-    ssl: [verify: :verify_peer]
+    XHTTP.Transport.SSL => [verify: :verify_peer]
   }
 
   @transport_opts [
@@ -38,17 +38,17 @@ defmodule XHTTPN.Conn do
   def stream(conn, message), do: conn_module(conn).stream(conn, message)
 
   defp negotiate(hostname, port, opts) do
-    transport = get_transport(opts, :ssl)
+    transport = get_transport(opts, XHTTP.Transport.SSL)
 
     transport_opts =
       Map.get(@default_transport_opts, transport, [])
       |> Keyword.merge(Keyword.get(opts, :transport_opts, []))
       |> Keyword.merge(@transport_opts)
 
-    with {:ok, socket} <- transport.connect(String.to_charlist(hostname), port, transport_opts) do
+    with {:ok, socket} <- transport.connect(hostname, port, transport_opts) do
       case transport do
-        :gen_tcp -> http1_with_upgrade(socket, hostname, port, opts)
-        :ssl -> alpn_negotiate(socket, hostname, port, transport, opts)
+        XHTTP.Transport.TCP -> http1_with_upgrade(socket, hostname, port, opts)
+        XHTTP.Transport.SSL -> alpn_negotiate(socket, hostname, port, transport, opts)
       end
     end
   end

--- a/test/xhttp1/conn_properties_test.exs
+++ b/test/xhttp1/conn_properties_test.exs
@@ -7,7 +7,7 @@ defmodule XHTTP1.ConnPropertiesTest do
 
   setup do
     {:ok, port} = TestServer.start()
-    assert {:ok, conn} = Conn.connect("localhost", port, transport: :gen_tcp)
+    assert {:ok, conn} = Conn.connect("localhost", port, transport: XHTTP.Transport.TCP)
     [conn: conn]
   end
 

--- a/test/xhttp1/conn_test.exs
+++ b/test/xhttp1/conn_test.exs
@@ -5,7 +5,7 @@ defmodule XHTTP1.ConnTest do
 
   setup do
     {:ok, port} = TestServer.start()
-    assert {:ok, conn} = Conn.connect("localhost", port, transport: :gen_tcp)
+    assert {:ok, conn} = Conn.connect("localhost", port, transport: XHTTP.Transport.TCP)
     [conn: conn]
   end
 

--- a/test/xhttp1/integration_test.exs
+++ b/test/xhttp1/integration_test.exs
@@ -23,7 +23,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "httpbin.org",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [cacertfile: "test/support/cacerts.pem"]
              )
 
@@ -42,7 +42,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "httpbin.org",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [cacertfile: "test/support/cacerts.pem"]
              )
 
@@ -59,7 +59,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "httpbin.org",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [cacertfile: "test/support/cacerts.pem"]
              )
 
@@ -169,7 +169,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "untrusted-root.badssl.com",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [cacertfile: "test/support/cacerts.pem", log_alert: false]
              )
 
@@ -177,7 +177,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "untrusted-root.badssl.com",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [verify: :verify_none]
              )
   end
@@ -187,7 +187,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "wrong.host.badssl.com",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [cacertfile: "test/support/cacerts.pem", log_alert: false]
              )
 
@@ -195,7 +195,7 @@ defmodule XHTTP1.IntegrationTest do
              Conn.connect(
                "wrong.host.badssl.com",
                443,
-               transport: :ssl,
+               transport: XHTTP.Transport.SSL,
                transport_opts: [verify: :verify_none]
              )
   end

--- a/test/xhttp2/conn_test.exs
+++ b/test/xhttp2/conn_test.exs
@@ -17,7 +17,12 @@ defmodule XHTTP2.ConnTest do
       TestServer.start_accepting(server)
 
       {:ok, conn} =
-        Conn.connect("localhost", port, transport: :ssl, transport_opts: [verify: :verify_none])
+        Conn.connect(
+          "localhost",
+          port,
+          transport: XHTTP.Transport.SSL,
+          transport_opts: [verify: :verify_none]
+        )
 
       on_exit(fn ->
         TestServer.stop(server)
@@ -28,7 +33,7 @@ defmodule XHTTP2.ConnTest do
   end
 
   test "using an unknown transport raises an error" do
-    message = "the :transport option must be either :gen_tcp or :ssl, got: :some_transport"
+    message = "the :transport option must be either TCP or SSL, got: :some_transport"
 
     assert_raise ArgumentError, message, fn ->
       Conn.connect("localhost", 80, transport: :some_transport)

--- a/test/xhttpn/integration_test.exs
+++ b/test/xhttpn/integration_test.exs
@@ -10,7 +10,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "httpbin.org",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  transport_opts: [cacertfile: "test/support/cacerts.pem"]
                )
 
@@ -31,7 +31,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "httpbin.org",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  protocols: [:http2],
                  transport_opts: [cacertfile: "test/support/cacerts.pem"]
                )
@@ -44,7 +44,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "nghttp2.org",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  protocols: [:http1],
                  transport_opts: [verify: :verify_none]
                )
@@ -65,7 +65,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "nghttp2.org",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  transport_opts: [verify: :verify_none]
                )
 
@@ -91,7 +91,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "untrusted-root.badssl.com",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  transport_opts: [cacertfile: "test/support/cacerts.pem", log_alert: false]
                )
 
@@ -99,7 +99,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "untrusted-root.badssl.com",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  transport_opts: [verify: :verify_none]
                )
     end
@@ -109,7 +109,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "wrong.host.badssl.com",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  transport_opts: [cacertfile: "test/support/cacerts.pem", log_alert: false]
                )
 
@@ -117,7 +117,7 @@ defmodule XHTTPN.IntegrationTest do
                Conn.connect(
                  "wrong.host.badssl.com",
                  443,
-                 transport: :ssl,
+                 transport: XHTTP.Transport.SSL,
                  transport_opts: [verify: :verify_none]
                )
     end


### PR DESCRIPTION
This is the first step towards abstracting transports so that we can use conns as transport (for proxying). This PR only adds a `XHTTP.Transport` behaviour and wraps `:ssl` and `:gen_tcp` in the right modules implementing the behaviour. The next step would be to change the behaviour so that functions are stateful: right now the socket doesn't get changed so the change would be minimal but it will be very important in the future when we have a conn transport.

\cc @josevalim, if you want to take a peek as well :)