### PR TITLE
Make transport operations stateful

### DIFF
--- a/lib/xhttp/transport.ex
+++ b/lib/xhttp/transport.ex
@@ -6,8 +6,7 @@ defmodule XHTTP.Transport do
   @callback connect(host :: String.t(), port :: :inet.port_number(), opts :: keyword()) ::
               {:ok, state()} | error()
 
-  @callback negotiated_protocol(state()) ::
-              {:ok, protocol :: binary()} | {:error, reason :: term()}
+  @callback negotiated_protocol(state()) :: {:ok, protocol :: binary()} | error()
 
   @callback send(state(), payload :: iodata()) :: {:ok, state()} | error()
 

--- a/lib/xhttp/transport.ex
+++ b/lib/xhttp/transport.ex
@@ -1,23 +1,23 @@
 defmodule XHTTP.Transport do
   @type state() :: term()
 
-  @callback connect(host :: String.t(), port :: :inet.port_number(), opts :: Keyword.t()) ::
-              {:ok, state()} | {:error, reason :: term()}
+  @type error() :: {:error, reason :: term()}
+
+  @callback connect(host :: String.t(), port :: :inet.port_number(), opts :: keyword()) ::
+              {:ok, state()} | error()
 
   @callback negotiated_protocol(state()) ::
               {:ok, protocol :: binary()} | {:error, reason :: term()}
 
-  @callback send(state(), payload :: iodata()) :: :ok | {:error, reason :: term()}
+  @callback send(state(), payload :: iodata()) :: {:ok, state()} | error()
 
-  @callback close(state()) :: :ok | {:error, reason :: term()}
+  @callback close(state()) :: {:ok, state()} | error()
 
-  @callback recv(state(), bytes :: non_neg_integer()) ::
-              {:ok, binary()} | {:error, reason :: term()}
+  @callback recv(state(), bytes :: non_neg_integer()) :: {:ok, binary(), state()} | error()
 
-  @callback setopts(state(), opts :: Keyword.t()) :: :ok | {:error, reason :: term()}
+  @callback setopts(state(), opts :: keyword()) :: :ok | error()
 
-  @callback getopts(state(), opts :: Keyword.t()) ::
-              {:ok, Keyword.t()} | {:error, reason :: term()}
+  @callback getopts(state(), opts :: keyword()) :: {:ok, opts :: keyword()} | error()
 
   @optional_callbacks [negotiated_protocol: 1]
 end

--- a/lib/xhttp/transport/ssl.ex
+++ b/lib/xhttp/transport/ssl.ex
@@ -12,13 +12,25 @@ defmodule XHTTP.Transport.SSL do
   defdelegate negotiated_protocol(socket), to: :ssl
 
   @impl true
-  defdelegate send(socket, payload), to: :ssl
+  def send(socket, payload) do
+    with :ok <- :ssl.send(socket, payload) do
+      {:ok, socket}
+    end
+  end
 
   @impl true
-  defdelegate close(socket), to: :ssl
+  def close(socket) do
+    with :ok <- :ssl.close(socket) do
+      {:ok, socket}
+    end
+  end
 
   @impl true
-  defdelegate recv(socket, bytes), to: :ssl
+  def recv(socket, bytes) do
+    with {:ok, data} <- :ssl.recv(socket, bytes) do
+      {:ok, data, socket}
+    end
+  end
 
   @impl true
   defdelegate setopts(socket, opts), to: :ssl

--- a/lib/xhttp/transport/tcp.ex
+++ b/lib/xhttp/transport/tcp.ex
@@ -9,13 +9,25 @@ defmodule XHTTP.Transport.TCP do
   end
 
   @impl true
-  defdelegate send(socket, payload), to: :gen_tcp
+  def send(socket, payload) do
+    with :ok <- :gen_tcp.send(socket, payload) do
+      {:ok, socket}
+    end
+  end
 
   @impl true
-  defdelegate close(socket), to: :gen_tcp
+  def close(socket) do
+    with :ok <- :gen_tcp.close(socket) do
+      {:ok, socket}
+    end
+  end
 
   @impl true
-  defdelegate recv(socket, bytes), to: :gen_tcp
+  def recv(socket, bytes) do
+    with {:ok, data} <- :gen_tcp.recv(socket, bytes) do
+      {:ok, data, socket}
+    end
+  end
 
   @impl true
   defdelegate setopts(socket, opts), to: :inet

--- a/test/xhttp1/conn_properties_test.exs
+++ b/test/xhttp1/conn_properties_test.exs
@@ -18,7 +18,9 @@ defmodule XHTTP1.ConnPropertiesTest do
     check all byte_chunks <- random_chunks(response) do
       {conn, responses} =
         Enum.reduce(byte_chunks, {conn, []}, fn bytes, {conn, responses} ->
-          assert {:ok, conn, new_responses} = Conn.stream(conn, {:tcp, conn.socket, bytes})
+          assert {:ok, conn, new_responses} =
+                   Conn.stream(conn, {:tcp, conn.transport_state, bytes})
+
           {conn, responses ++ new_responses}
         end)
 
@@ -41,7 +43,9 @@ defmodule XHTTP1.ConnPropertiesTest do
     check all byte_chunks <- random_chunks(response) do
       {conn, responses} =
         Enum.reduce(byte_chunks, {conn, []}, fn bytes, {conn, responses} ->
-          assert {:ok, conn, new_responses} = Conn.stream(conn, {:tcp, conn.socket, bytes})
+          assert {:ok, conn, new_responses} =
+                   Conn.stream(conn, {:tcp, conn.transport_state, bytes})
+
           {conn, responses ++ new_responses}
         end)
 
@@ -64,7 +68,9 @@ defmodule XHTTP1.ConnPropertiesTest do
     check all byte_chunks <- random_chunks(responses) do
       {_conn, responses} =
         Enum.reduce(byte_chunks, {conn, []}, fn bytes, {conn, responses} ->
-          assert {:ok, conn, new_responses} = Conn.stream(conn, {:tcp, conn.socket, bytes})
+          assert {:ok, conn, new_responses} =
+                   Conn.stream(conn, {:tcp, conn.transport_state, bytes})
+
           {conn, responses ++ new_responses}
         end)
 

--- a/test/xhttp1/conn_test.exs
+++ b/test/xhttp1/conn_test.exs
@@ -18,33 +18,40 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
 
     assert {:ok, _conn, [{:status, ^ref, 200}]} =
-             Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+             Conn.stream(conn, {:tcp, conn.transport_state, "HTTP/1.1 200 OK\r\n"})
   end
 
   test "partial status", %{conn: conn} do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1"})
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "HTTP/1.1"})
 
     assert {:ok, _conn, [{:status, ^ref, 200}]} =
-             Conn.stream(conn, {:tcp, conn.socket, " 200 OK\r\n"})
+             Conn.stream(conn, {:tcp, conn.transport_state, " 200 OK\r\n"})
   end
 
   test "headers", %{conn: conn} do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
-    assert {:ok, conn, [_status]} = Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
+
+    assert {:ok, conn, [_status]} =
+             Conn.stream(conn, {:tcp, conn.transport_state, "HTTP/1.1 200 OK\r\n"})
 
     assert {:ok, _conn, [headers]} =
-             Conn.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nBaz: Boz\r\n\r\n"})
+             Conn.stream(conn, {:tcp, conn.transport_state, "Foo: Bar\r\nBaz: Boz\r\n\r\n"})
 
     assert {:headers, ^ref, [{"foo", "Bar"}, {"baz", "Boz"}]} = headers
   end
 
   test "partial headers", %{conn: conn} do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
-    assert {:ok, conn, [_status]} = Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n"})
 
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "Foo: Bar\r\nB"})
-    assert {:ok, _conn, [headers]} = Conn.stream(conn, {:tcp, conn.socket, "az: Boz\r\n\r\n"})
+    assert {:ok, conn, [_status]} =
+             Conn.stream(conn, {:tcp, conn.transport_state, "HTTP/1.1 200 OK\r\n"})
+
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "Foo: Bar\r\nB"})
+
+    assert {:ok, _conn, [headers]} =
+             Conn.stream(conn, {:tcp, conn.transport_state, "az: Boz\r\n\r\n"})
+
     assert {:headers, ^ref, [{"foo", "Bar"}, {"baz", "Boz"}]} = headers
   end
 
@@ -52,7 +59,10 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
 
     assert {:ok, _conn, [status, headers]} =
-             Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\nFoo: Bar\r\n\r\n"})
+             Conn.stream(
+               conn,
+               {:tcp, conn.transport_state, "HTTP/1.1 200 OK\r\nFoo: Bar\r\n\r\n"}
+             )
 
     assert {:status, ^ref, 200} = status
     assert {:headers, ^ref, [{"foo", "Bar"}]} = headers
@@ -62,11 +72,12 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
 
     assert {:ok, conn, [_status, _headers, {:data, ^ref, "BODY1"}]} =
-             Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n\r\nBODY1"})
+             Conn.stream(conn, {:tcp, conn.transport_state, "HTTP/1.1 200 OK\r\n\r\nBODY1"})
 
-    assert {:ok, conn, [{:data, ^ref, "BODY2"}]} = Conn.stream(conn, {:tcp, conn.socket, "BODY2"})
+    assert {:ok, conn, [{:data, ^ref, "BODY2"}]} =
+             Conn.stream(conn, {:tcp, conn.transport_state, "BODY2"})
 
-    assert {:ok, conn, [{:done, ^ref}]} = Conn.stream(conn, {:tcp_closed, conn.socket})
+    assert {:ok, conn, [{:done, ^ref}]} = Conn.stream(conn, {:tcp_closed, conn.transport_state})
     refute Conn.open?(conn)
   end
 
@@ -74,13 +85,14 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
     response = "HTTP/1.1 200 OK\r\ncontent-length: 10\r\n\r\n"
 
-    assert {:ok, conn, [_status, _headers]} = Conn.stream(conn, {:tcp, conn.socket, response})
+    assert {:ok, conn, [_status, _headers]} =
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert {:ok, conn, [{:data, ^ref, "012345678"}]} =
-             Conn.stream(conn, {:tcp, conn.socket, "012345678"})
+             Conn.stream(conn, {:tcp, conn.transport_state, "012345678"})
 
     assert {:ok, conn, [{:data, ^ref, "9"}, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, "9XXX"})
+             Conn.stream(conn, {:tcp, conn.transport_state, "9XXX"})
 
     assert conn.buffer == "XXX"
     assert Conn.open?(conn)
@@ -90,7 +102,7 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref} = Conn.request(conn, "HEAD", "/", [], nil)
 
     assert {:ok, conn, [_status, _headers, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, "HTTP/1.1 200 OK\r\n\r\nXXX"})
+             Conn.stream(conn, {:tcp, conn.transport_state, "HTTP/1.1 200 OK\r\n\r\nXXX"})
 
     assert conn.buffer == "XXX"
   end
@@ -100,9 +112,9 @@ defmodule XHTTP1.ConnTest do
     response = "HTTP/1.1 200 OK\r\ncontent-length: 1\r\n\r\nXX"
 
     assert {:ok, conn, [_status, _headers, {:data, ^ref, "X"}, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "X"})
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "X"})
 
     assert conn.buffer == "XX"
   end
@@ -112,9 +124,9 @@ defmodule XHTTP1.ConnTest do
     response = "HTTP/1.1 200 OK\r\ncontent-length: 1\r\nconnection: close\r\n\r\nX"
 
     assert {:ok, conn, [_status, _headers, {:data, ^ref, "X"}, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "X"})
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "X"})
     refute Conn.open?(conn)
   end
 
@@ -123,9 +135,9 @@ defmodule XHTTP1.ConnTest do
     response = "HTTP/1.0 200 OK\r\ncontent-length: 1\r\nconnection: keep-alive\r\n\r\nX"
 
     assert {:ok, conn, [_status, _headers, {:data, ^ref, "X"}, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "X"})
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "X"})
     assert Conn.open?(conn)
   end
 
@@ -134,9 +146,9 @@ defmodule XHTTP1.ConnTest do
     response = "HTTP/1.0 200 OK\r\ncontent-length: 1\r\n\r\nX"
 
     assert {:ok, conn, [_status, _headers, {:data, ^ref, "X"}, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "X"})
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "X"})
     refute Conn.open?(conn)
   end
 
@@ -145,9 +157,9 @@ defmodule XHTTP1.ConnTest do
     response = "HTTP/1.1 200 OK\r\ncontent-length: 1\r\n\r\nX"
 
     assert {:ok, conn, [_status, _headers, {:data, ^ref, "X"}, {:done, ^ref}]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
-    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.socket, "X"})
+    assert {:ok, conn, []} = Conn.stream(conn, {:tcp, conn.transport_state, "X"})
     assert Conn.open?(conn)
   end
 
@@ -155,7 +167,8 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref} = Conn.request(conn, "GET", "/", [], nil)
     response = "HTTP/1.1 200 OK\r\ncontent-length: 2\r\ncontent-length: 3\r\n\r\nX"
 
-    assert {:error, ^ref, :invalid_response} = Conn.stream(conn, {:tcp, conn.socket, response})
+    assert {:error, ^ref, :invalid_response} =
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
   end
 
   test "pipeline", %{conn: conn} do
@@ -165,22 +178,22 @@ defmodule XHTTP1.ConnTest do
     {:ok, conn, ref4} = Conn.request(conn, "GET", "/", [], nil)
     response = "HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nXXXXX"
 
-    assert {:ok, conn, responses} = Conn.stream(conn, {:tcp, conn.socket, response})
+    assert {:ok, conn, responses} = Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert [{:status, ^ref1, _}, {:headers, ^ref1, _}, {:data, ^ref1, "XXXXX"}, {:done, ^ref1}] =
              responses
 
-    assert {:ok, conn, responses} = Conn.stream(conn, {:tcp, conn.socket, response})
+    assert {:ok, conn, responses} = Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert [{:status, ^ref2, _}, {:headers, ^ref2, _}, {:data, ^ref2, "XXXXX"}, {:done, ^ref2}] =
              responses
 
-    assert {:ok, conn, responses} = Conn.stream(conn, {:tcp, conn.socket, response})
+    assert {:ok, conn, responses} = Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert [{:status, ^ref3, _}, {:headers, ^ref3, _}, {:data, ^ref3, "XXXXX"}, {:done, ^ref3}] =
              responses
 
-    assert {:ok, _conn, responses} = Conn.stream(conn, {:tcp, conn.socket, response})
+    assert {:ok, _conn, responses} = Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert [{:status, ^ref4, _}, {:headers, ^ref4, _}, {:data, ^ref4, "XXXXX"}, {:done, ^ref4}] =
              responses
@@ -194,7 +207,7 @@ defmodule XHTTP1.ConnTest do
     response = "HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nXXXXX"
     responses = for _ <- 1..4, do: response, into: ""
 
-    assert {:ok, _conn, responses} = Conn.stream(conn, {:tcp, conn.socket, responses})
+    assert {:ok, _conn, responses} = Conn.stream(conn, {:tcp, conn.transport_state, responses})
 
     assert [
              {:status, ^ref1, _},
@@ -224,7 +237,7 @@ defmodule XHTTP1.ConnTest do
         "2\r\n01\r\n2\r\n23\r\n0\r\n\r\nXXX"
 
     assert {:ok, conn, [status, headers, body, done]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert status == {:status, ref, 200}
     assert headers == {:headers, ref, [{"transfer-encoding", "chunked"}]}
@@ -242,7 +255,7 @@ defmodule XHTTP1.ConnTest do
         "2meta\r\n01\r\n2\r\n23\r\n0meta\r\ntrailer: value\r\n\r\nXXX"
 
     assert {:ok, conn, [status, headers, body, trailers, done]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert status == {:status, ref, 200}
     assert headers == {:headers, ref, [{"transfer-encoding", "chunked"}]}
@@ -261,7 +274,7 @@ defmodule XHTTP1.ConnTest do
         "2\r\n01\r\n2\r\n23\r\n0\r\n\r\nXXX"
 
     assert {:ok, _conn, [status, headers, body]} =
-             Conn.stream(conn, {:tcp, conn.socket, response})
+             Conn.stream(conn, {:tcp, conn.transport_state, response})
 
     assert status == {:status, ref, 200}
     assert headers == {:headers, ref, [{"transfer-encoding", "custom, chunked"}]}

--- a/test/xhttp2/conn_test.exs
+++ b/test/xhttp2/conn_test.exs
@@ -45,12 +45,14 @@ defmodule XHTTP2.ConnTest do
   end
 
   test "closed-socket messages are treated as errors", %{conn: conn} do
-    assert {:error, %Conn{} = conn, :closed, []} = Conn.stream(conn, {:ssl_closed, conn.socket})
+    assert {:error, %Conn{} = conn, :closed, []} =
+             Conn.stream(conn, {:ssl_closed, conn.transport_state})
+
     refute Conn.open?(conn)
   end
 
   test "socket error messages are treated as errors", %{conn: conn} do
-    message = {:ssl_error, conn.socket, :etimeout}
+    message = {:ssl_error, conn.transport_state, :etimeout}
     assert {:error, %Conn{} = conn, :etimeout, []} = Conn.stream(conn, message)
     refute Conn.open?(conn)
   end


### PR DESCRIPTION
I left some operations (like `getopts` and `setopts`) stateless for now as I don't think we'll need to make them stateful. Also, I left TCP/SSL messages untouched for now as I think we'll need to add callbacks for streaming messages (so that for example a proxy conn transport can delegate the streaming to the underlying TCP/SSL transport).

\cc @josevalim as always <3