### PR TITLE
Support wildcards in certificate SAN extension

### DIFF
--- a/test/support/xhttp/wildcard_san.pem
+++ b/test/support/xhttp/wildcard_san.pem
@@ -1,0 +1,53 @@
+# Retrieved from outlook.office365.com on 18/05/2018
+
+# X509v3 Subject Alternative Name:
+#   DNS:*.clo.footprintdns.com, DNS:*.nrb.footprintdns.com, DNS:*.hotmail.com,
+#   DNS:*.internal.outlook.com, DNS:*.live.com, DNS:*.office.com,
+#   DNS:*.office365.com, DNS:*.outlook.com, DNS:*.outlook.office365.com,
+#   DNS:attachment.outlook.live.net, DNS:attachment.outlook.office.net,
+#   DNS:attachment.outlook.officeppe.net, DNS:ccs.login.microsoftonline.com,
+#   DNS:ccs-sdf.login.microsoftonline.com, DNS:hotmail.com,
+#   DNS:mail.services.live.com, DNS:office365.com, DNS:outlook.com,
+#   DNS:outlook.office.com, DNS:substrate.office.com,
+#   DNS:substrate-sdf.office.com
+
+-----BEGIN CERTIFICATE-----
+MIIG/jCCBeagAwIBAgIQDs2Q7J6KkeHe1d6ecU8P9DANBgkqhkiG9w0BAQsFADBL
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMSUwIwYDVQQDExxE
+aWdpQ2VydCBDbG91ZCBTZXJ2aWNlcyBDQS0xMB4XDTE3MDkxMzAwMDAwMFoXDTE4
+MDkxMzEyMDAwMFowajELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24x
+EDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlv
+bjEUMBIGA1UEAxMLb3V0bG9vay5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+ggEKAoIBAQC38AIorGo1Jr6unjupBpQXrKPztgJyyuQIz5WywwxDow4FPx6sdOni
+GSRKbaBpokFQ0sBaAw3rzJNBGlNRm2dEdgLsvW+lUbSixKz6W+beVYjbEIsKTRL0
+2YCxMfkgH8pCiLn7hxZ+iizkC4czbtMQ3FYN4f8gr7Lg+T++Pe86p7p2nGylGH8f
+aQvdEeWAPWZv9Xn2Yzd198n2trCIjRfG+EAtWIYf2+D3Rt7WKz7jL8Jtw/7aBF9r
+BYRp0ZDeSBqZmh5hxuQv8SEkykRRXW9I9hTr+qj0MDmvgoqlDnGn2Eq8wfRxe3KL
+tlFkvJCYnB/4geNzQXd0qWF0t1ek9uSDAgMBAAGjggO9MIIDuTAfBgNVHSMEGDAW
+gBTdUdCiMXOpc66PtAF+XYxXy5/w9zAdBgNVHQ4EFgQU/LTuF7+AgdxpZFZ7/uCm
+hm21hNQwggHcBgNVHREEggHTMIIBz4IWKi5jbG8uZm9vdHByaW50ZG5zLmNvbYIW
+Ki5ucmIuZm9vdHByaW50ZG5zLmNvbYINKi5ob3RtYWlsLmNvbYIWKi5pbnRlcm5h
+bC5vdXRsb29rLmNvbYIKKi5saXZlLmNvbYIMKi5vZmZpY2UuY29tgg8qLm9mZmlj
+ZTM2NS5jb22CDSoub3V0bG9vay5jb22CFyoub3V0bG9vay5vZmZpY2UzNjUuY29t
+ghthdHRhY2htZW50Lm91dGxvb2subGl2ZS5uZXSCHWF0dGFjaG1lbnQub3V0bG9v
+ay5vZmZpY2UubmV0giBhdHRhY2htZW50Lm91dGxvb2sub2ZmaWNlcHBlLm5ldIId
+Y2NzLmxvZ2luLm1pY3Jvc29mdG9ubGluZS5jb22CIWNjcy1zZGYubG9naW4ubWlj
+cm9zb2Z0b25saW5lLmNvbYILaG90bWFpbC5jb22CFm1haWwuc2VydmljZXMubGl2
+ZS5jb22CDW9mZmljZTM2NS5jb22CC291dGxvb2suY29tghJvdXRsb29rLm9mZmlj
+ZS5jb22CFHN1YnN0cmF0ZS5vZmZpY2UuY29tghhzdWJzdHJhdGUtc2RmLm9mZmlj
+ZS5jb20wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF
+BQcDAjCBjQYDVR0fBIGFMIGCMD+gPaA7hjlodHRwOi8vY3JsMy5kaWdpY2VydC5j
+b20vRGlnaUNlcnRDbG91ZFNlcnZpY2VzQ0EtMS1nMS5jcmwwP6A9oDuGOWh0dHA6
+Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydENsb3VkU2VydmljZXNDQS0xLWcx
+LmNybDBMBgNVHSAERTBDMDcGCWCGSAGG/WwBATAqMCgGCCsGAQUFBwIBFhxodHRw
+czovL3d3dy5kaWdpY2VydC5jb20vQ1BTMAgGBmeBDAECAjB8BggrBgEFBQcBAQRw
+MG4wJQYIKwYBBQUHMAGGGWh0dHA6Ly9vY3NweC5kaWdpY2VydC5jb20wRQYIKwYB
+BQUHMAKGOWh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydENsb3Vk
+U2VydmljZXNDQS0xLmNydDAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IB
+AQBipSHmHGuSR5TgrmqCORJMtwvNEUhRQ3lMy6h/CBqCS/0dKVw8J28cVoQBY8Z4
+lRDx4vTHGQiUzHY6EwgJ5iGRqgxUX/NmO4dJnC7IpKbdY/v1b9KKGzFpw27OkXqk
+nGhseM2tJfwa2HMwUpuuo5029u4Dd40qvD0cMz33cOvBLRGkTPbXCFw24ZBdQrkt
+SC5TAWzHFyT2tLC17LeSb7d0g+fuj41L6y4a9och8cPiv9IAP4sftzYupO99h4qg
+7UXP7o3AOOGqrPS3INhO4068Z63indstanIHYM0IUHa3A2xrcz7ZbEuw1HiGH/Ba
+HMz/gTSd2c0BXNiPeM7gdOK3
+-----END CERTIFICATE-----


### PR DESCRIPTION
Workaround for https://bugs.erlang.org/browse/ERL-542

This also always uses the packaged `pkix_verify_hostname` function, regardless of whether the function is available and activated in the current OTP version.