### PR TITLE
Remove duplicate socket closing statement

### DIFF
--- a/lib/xhttp/util.ex
+++ b/lib/xhttp/util.ex
@@ -4,10 +4,6 @@ defmodule XHTTP.Util do
          buffer = calculate_buffer(opts),
          :ok <- transport.setopts(socket, buffer: buffer) do
       :ok
-    else
-      error ->
-        transport.close(socket)
-        error
     end
   end
 


### PR DESCRIPTION
I realized that the socket will be handled in the callers ([`XHTTP1.Conn`](https://github.com/ericmj/xhttp/blob/116b93a68ec7cd60db00e7da5c6490ea7356f63b/lib/xhttp1/conn.ex#L102) and [`XHTTP2.Conn`](https://github.com/ericmj/xhttp/blob/116b93a68ec7cd60db00e7da5c6490ea7356f63b/lib/xhttp2/conn.ex#L329)), so perhaps there's no need to close it twice or did I miss anything?